### PR TITLE
Replace @test of JUnit4 with JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             <artifactId>mybatis-spring-boot-starter-test</artifactId>
             <version>1.3.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 

--- a/src/main/java/me/nexters/chopstatsapi/domain/PlatformVO.java
+++ b/src/main/java/me/nexters/chopstatsapi/domain/PlatformVO.java
@@ -1,6 +1,7 @@
 package me.nexters.chopstatsapi.domain;
 
 import lombok.Getter;
+import lombok.ToString;
 import org.apache.ibatis.type.Alias;
 
 /**
@@ -8,6 +9,7 @@ import org.apache.ibatis.type.Alias;
  */
 @Alias("platform_count")
 @Getter
+@ToString
 public class PlatformVO {
     private int mobile;
     private int browser;

--- a/src/test/java/me/nexters/chopstatsapi/ChopStatsApiApplicationTests.java
+++ b/src/test/java/me/nexters/chopstatsapi/ChopStatsApiApplicationTests.java
@@ -1,11 +1,10 @@
 package me.nexters.chopstatsapi;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
 @SpringBootTest
 public class ChopStatsApiApplicationTests {
 

--- a/src/test/java/me/nexters/chopstatsapi/grpc/UrlClickGrpcServiceTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/grpc/UrlClickGrpcServiceTest.java
@@ -8,95 +8,69 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import me.nexters.chopstatsapi.rabbitmq.producer.Producer;
-import me.nexters.chopstatsapi.repository.UrlClickRepository;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 
 
 /**
  * @author junho.park
  */
-@RunWith(SpringRunner.class)
-@SpringBootTest
+
+@RunWith(MockitoJUnitRunner.class)
 public class UrlClickGrpcServiceTest {
+    private static final String SERVER_NAME = InProcessServerBuilder.generateName();
+
     @Rule
     public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
-    private ManagedChannel inProcessChannel;
+    @Mock
+    private StreamObserver<Success> responseObserver;
 
-    private Server server;
+    private ManagedChannel inProcessChannel = grpcCleanup.register(InProcessChannelBuilder
+            .forName(SERVER_NAME)
+            .directExecutor()
+            .build());
 
-    @Autowired
-    private UrlClickRepository urlClickRepository;
-
-    @Autowired
-    private Producer producer;
-
-    @Before
-    public void setUp() throws Exception {
-        String serverName = UUID.randomUUID().toString();
-        server = InProcessServerBuilder
-                .forName(serverName)
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        Producer producer = mock(Producer.class);
+        Server server = InProcessServerBuilder
+                .forName(SERVER_NAME)
                 .directExecutor()
                 .addService(new UrlClickGrpcService(producer)).build();
 
         server.start();
 
-        // 클라이언트 채널을 만들고 위에서 등록한 GrpcCleanupRule을 적용해 추후 셧다운을 시킨다.
-        inProcessChannel = grpcCleanup.register(
-                InProcessChannelBuilder.forName(serverName).directExecutor().build());
     }
 
-
     @Test
-    public void unaryRecordCount() {
-        long millis = System.currentTimeMillis();
-        Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
-                .setNanos((int) ((millis % 1000) * 1000000)).build();
-        Url url1 = Url.newBuilder()
-                .setClickTime(timestamp)
+    public void shouldInvokeOnCompleted() {
+        Url url = makeSimpleUrl();
+        UrlClickServiceGrpc.UrlClickServiceStub stub = UrlClickServiceGrpc.newStub(inProcessChannel);
+
+        stub.unaryRecordCount(url, responseObserver);
+
+        then(responseObserver).should(timeout(1)).onNext(any());
+        then(responseObserver).should(timeout(1)).onCompleted();
+
+    }
+
+    private Url makeSimpleUrl() {
+        return Url.newBuilder()
+                .setClickTime(Timestamp.newBuilder())
                 .setShortUrl("O1")
                 .setReferer("https://www.nexters.com")
                 .setPlatform("Mobile")
                 .build();
-
-        UrlClickServiceGrpc.UrlClickServiceStub stub = UrlClickServiceGrpc.newStub(inProcessChannel);
-
-        stub.unaryRecordCount(url1, new StreamObserver<Success>() {
-            @Override
-            public void onNext(Success success) {
-                assertThat(success.getMessage()).isEqualTo("save success : " + "a");
-            }
-
-            @Override
-            public void onError(Throwable throwable) {
-                System.out.println(throwable.getMessage());
-            }
-
-            @Override
-            public void onCompleted() {
-                System.out.println("서버 응답 종료");
-            }
-        });
-
-        sleep();
-
     }
 
-    private void sleep() {
-        try {
-            Thread.sleep(3000);
-        } catch (Exception e) {
-
-        }
-    }
 }

--- a/src/test/java/me/nexters/chopstatsapi/grpc/util/DomainParserTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/grpc/util/DomainParserTest.java
@@ -4,8 +4,8 @@ package me.nexters.chopstatsapi.grpc.util;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class DomainParserTest {
 

--- a/src/test/java/me/nexters/chopstatsapi/mapper/PlatformMapperTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/mapper/PlatformMapperTest.java
@@ -1,17 +1,15 @@
 package me.nexters.chopstatsapi.mapper;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import me.nexters.chopstatsapi.repository.mapper.PlatformMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 /**
  * @author junho.park
  */
-@RunWith(SpringRunner.class)
+
 @SpringBootTest
 public class PlatformMapperTest {
 

--- a/src/test/java/me/nexters/chopstatsapi/mapper/PlatformMapperTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/mapper/PlatformMapperTest.java
@@ -2,15 +2,23 @@ package me.nexters.chopstatsapi.mapper;
 
 
 import me.nexters.chopstatsapi.repository.mapper.PlatformMapper;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static org.springframework.boot.jdbc.EmbeddedDatabaseConnection.H2;
+
 /**
- * @author junho.park
+ * @author chulwoon.jang
  */
 
+@Disabled
+@MybatisTest
 @SpringBootTest
+@AutoConfigureTestDatabase(connection = H2)
 public class PlatformMapperTest {
 
     @Autowired

--- a/src/test/java/me/nexters/chopstatsapi/produce/ProducerTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/produce/ProducerTest.java
@@ -1,22 +1,19 @@
 package me.nexters.chopstatsapi.produce;
 
-import java.util.Date;
-
 import me.nexters.chopstatsapi.rabbitmq.QueueManager;
 import me.nexters.chopstatsapi.rabbitmq.model.ClickDateCount;
 import me.nexters.chopstatsapi.rabbitmq.model.PlatformCount;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import me.nexters.chopstatsapi.rabbitmq.producer.Producer;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
-
-import me.nexters.chopstatsapi.rabbitmq.producer.Producer;
 
 /**
  * @author manki.kim
  */
-@RunWith(SpringRunner.class)
+
+@Disabled
 @SpringBootTest
 public class ProducerTest {
 

--- a/src/test/java/me/nexters/chopstatsapi/repository/ClickDateRepositoryTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/repository/ClickDateRepositoryTest.java
@@ -1,11 +1,9 @@
 package me.nexters.chopstatsapi.repository;
 
 import me.nexters.chopstatsapi.domain.ClickDateVO;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -13,7 +11,7 @@ import java.util.List;
 /**
  * @author junho.park
  */
-@RunWith(SpringRunner.class)
+
 @SpringBootTest
 @Transactional
 public class ClickDateRepositoryTest {

--- a/src/test/java/me/nexters/chopstatsapi/repository/PlatformRepositoryTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/repository/PlatformRepositoryTest.java
@@ -1,17 +1,16 @@
 package me.nexters.chopstatsapi.repository;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author junho.park
  */
-@RunWith(SpringRunner.class)
+
 @SpringBootTest
 public class PlatformRepositoryTest {
     @Autowired

--- a/src/test/java/me/nexters/chopstatsapi/repository/RefererRepositoryTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/repository/RefererRepositoryTest.java
@@ -1,11 +1,9 @@
 package me.nexters.chopstatsapi.repository;
 
 import me.nexters.chopstatsapi.domain.RefererVO;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.List;
 
@@ -14,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author junho.park
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest
 public class RefererRepositoryTest {
     @Autowired

--- a/src/test/java/me/nexters/chopstatsapi/repository/TotalCountRepositoryTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/repository/TotalCountRepositoryTest.java
@@ -1,18 +1,15 @@
 package me.nexters.chopstatsapi.repository;
 
 import me.nexters.chopstatsapi.domain.TotalCountVO;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author junho.park
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest
 public class TotalCountRepositoryTest {
     @Autowired

--- a/src/test/java/me/nexters/chopstatsapi/repository/UrlClickRepositoryTest.java
+++ b/src/test/java/me/nexters/chopstatsapi/repository/UrlClickRepositoryTest.java
@@ -1,18 +1,15 @@
 package me.nexters.chopstatsapi.repository;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 
 /**
  * @author junho.park
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest
 public class UrlClickRepositoryTest {
     @Autowired

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:h2:mem:foo;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+    <logger name="org.springframework" level="OFF"/>
+</configuration>

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS platform_count;
+
+CREATE TABLE platform_count (
+  id          INTEGER PRIMARY KEY,
+  short_url VARCHAR(64) NOT NULL,
+  mobile   VARCHAR(64),
+  browser VARCHAR(64));
+
+// TODO insert Data


### PR DESCRIPTION

> 작업 내역 

```
0. JUnit5 로 교체
1. RPC Test 수정
2. test scope 에 h2 적용
```

> 특이사항  

1. JUnit5 로 수정하면서, RPC 쪽에 이슈가 있어서 요부분은 JUnit4 로 냅뒀습니다.
GRPC-test 쪽에서 아직 JUnit5를 지원하지 않습니다.

2. GRPC 쪽에서 SpringRunner 를 삭제했습니다.
server 를 직접 올렷다, 내렷다하는 코드여서 굳이 spring을 띄울필요 없겠다 싶었어요 

> Integration TC면 상황이 다르겟지만, 단순 GPRC Test 라서 .. 

3. Test Scope에서 리얼DB를 바라보고있어서, h2를 바라보게 수정했습니다.

Connection 부분만 설정해뒀고, 초기 InsertData는 다음 PR에서 진행하겠습니다.


감사합니다 (_ _) 
