### PR TITLE
refactor: 불필요한 에러발생 삭제

### DIFF
--- a/src/main/java/me/nexters/chopstatsapi/grpc/StatsGrpcService.java
+++ b/src/main/java/me/nexters/chopstatsapi/grpc/StatsGrpcService.java
@@ -136,6 +136,5 @@ public class StatsGrpcService extends UrlStatsServiceGrpc.UrlStatsServiceImplBas
 
 	private void throwNotFoundException(StreamObserver response) {
 		response.onError(Status.NOT_FOUND.withDescription(UrlErrorHandler.NOT_FOUND.getMessage()).asException());
-		throw new HttpClientErrorException(HttpStatus.NOT_FOUND, UrlErrorHandler.NOT_FOUND.getMessage());
 	}
 }


### PR DESCRIPTION
이 예외는 통계앱쪽에서 발생하고 catch 가 되지 않음.
url이 단축되고 나서 통계 데이터가 하나도 없을 때 조회를 하면 데이터가 null 이지만 에러상황은 아니므로 예외를 던지지 않고 rpc를 호출한 쪽으로는 onError(NotFound)를 전달하고 자신은 처리하지 않는 것은 어떨지. (계속 에러 로그가 쌓여서 불편함) 

클라이언트 쪽에는 NotFound 예외처리가 되어 있음

<img width="807" alt="Screen Shot 2019-07-10 at 5 34 30 PM" src="https://user-images.githubusercontent.com/20608121/60954140-71d8ae80-a339-11e9-87d8-5051214d39a5.png">
이렇게 에러상황은 아닌데 계속 Error 로그가 쌓여성 ㅠ
